### PR TITLE
Fix depth not computed for second run.

### DIFF
--- a/spacy_pattern_builder/build.py
+++ b/spacy_pattern_builder/build.py
@@ -62,7 +62,6 @@ def build_dependency_pattern(doc, match_tokens, feature_dict=DEFAULT_BUILD_PATTE
     # Checks
     if not nx_graph:
         nx_graph = util.doc_to_nx_graph(doc)
-    util.annotate_token_depth(doc)
     connected_tokens = util.smallest_connected_subgraph(
         match_tokens, doc, nx_graph=nx_graph)
     match_token_ids = util.token_idxs(match_tokens)


### PR DESCRIPTION
Token depth is set to default `None` by spacy when
`set_extension` is called once.

We were computing depth only when attribute is not present.  This causes an error when we try to pattern match with another sentence.

Fixed this by following few spacy best practices for extensions.